### PR TITLE
Add support for python 3

### DIFF
--- a/dpsprep
+++ b/dpsprep
@@ -57,10 +57,10 @@ args.dest = home + '/.dpsprep/' + pipes.quote(args.dest)
 if os.path.isfile(tmp + '/inprocess'):
     fname = open(tmp + '/inprocess', 'r').read()
     if not fname == args.src:
-        print "ERROR: Attempting to process %s before %s is completed. Aborting." % (args.src, fname)
+        print("ERROR: Attempting to process %s before %s is completed. Aborting." % (args.src, fname))
         exit(3)
     else:
-        print "NOTE: Continuing to process %s..." % args.src
+        print("NOTE: Continuing to process %s..." % args.src)
 else:
     # Record the file we are about to process
     open(tmp + '/inprocess', 'w').write(args.src)
@@ -70,13 +70,13 @@ else:
 if not os.path.isfile(tmp + '/dumpd'):
     retval = os.system("ddjvu -v -eachpage -format=tiff %s %s/pg%%06d.tif" % (args.src, tmp))
     if retval > 0:
-        print "\nNOTE: There was a problem dumping the pages to tiff.  See above output"
+        print("\nNOTE: There was a problem dumping the pages to tiff.  See above output")
         exit(retval)
 
-    print "Flat PDF made."
+    print("Flat PDF made.")
     open(tmp + '/dumpd', 'a').close()
 else:
-    print "Inflated PDFs already found, using these..."
+    print("Inflated PDFs already found, using these...")
 
 # Extract and embed the text
 if not os.path.isfile(tmp + '/hocrd'):
@@ -85,13 +85,13 @@ if not os.path.isfile(tmp + '/hocrd'):
     for i in range(1,cnt):
         retval = os.system("djvu2hocr -p %d %s | sed 's/ocrx/ocr/g' > %s/pg%06d.html" % (i, args.src, tmp, i))
         if retval > 0:
-            print "\nNOTE: There was a problem extracting the OCRd text on page %d, see above output." % i
+            print("\nNOTE: There was a problem extracting the OCRd text on page %d, see above output." % i)
             exit(retval)
 
-    print "OCRd text extracted."
+    print("OCRd text extracted.")
     open(tmp + '/hocrd', 'a').close()
 else:
-    print "Using existing hOCRd output..."
+    print("Using existing hOCRd output...")
 
 # Is sloppy and dumps to present directory
 if not os.path.isfile(tmp + '/beadd'):
@@ -99,14 +99,14 @@ if not os.path.isfile(tmp + '/beadd'):
     os.chdir(tmp)
     retval = os.system('pdfbeads * > ' + args.dest)
     if retval > 0:
-        print "\nNOTE: There was a problem beading, see above output."
+        print("\nNOTE: There was a problem beading, see above output.")
         exit(retval)
     
-    print "Beading complete."
+    print("Beading complete.")
     open('beadd', 'a').close()
     os.chdir(cwd)
 else:
-    print "Existing destination found, assuming beading already complete..."
+    print("Existing destination found, assuming beading already complete...")
 
 ###########################$
 #
@@ -117,14 +117,14 @@ else:
 # (scratch)
 retval = 0
 retval = retval | os.system("djvused %s -u -e 'print-outline' > %s/bmarks.out" % (args.src, tmp))
-print "Bookmarks extracted."
+print("Bookmarks extracted.")
 
 # Check for zero-length outline
 if os.stat("%s/bmarks.out" % tmp).st_size > 0:
 
     # Extract the metadata from the PDF document
     retval = retval | os.system("pdftk %s dump_data_utf8 > %s/pdfmetadata.out" % (args.dest, tmp))
-    print "Original PDF metadata extracted."
+    print("Original PDF metadata extracted.")
 
     # Parse the sexpr
     pdfbmarks = walk_bmarks(sexpdata.load(open(tmp + '/bmarks.out')), 0)
@@ -144,13 +144,13 @@ if os.stat("%s/bmarks.out" % tmp).st_size > 0:
 
 else:
     retval = retval | os.system("mv %s %s" % (args.dest, finaldest))
-    print "No bookmarks were present!"
+    print("No bookmarks were present!")
 
 # If retval is shit, don't delete temp files
 if retval == 0:
     os.system("rm %s/*" % tmp)
-    print "SUCCESS. Temporary files cleared."
+    print("SUCCESS. Temporary files cleared.")
     exit(0)
 else:
-    print "There were errors in the metadata step.  OCRd text is fine, pdf is almost ready.  See above output for cluse"
+    print("There were errors in the metadata step.  OCRd text is fine, pdf is almost ready.  See above output for cluse")
     exit(retval)

--- a/dpsprep
+++ b/dpsprep
@@ -8,6 +8,7 @@ import argparse
 import os
 import pipes
 import subprocess
+import shutil
 import re
 
 # Recursively walks the sexpr tree and outputs a metadata format understandable by pdftk
@@ -40,6 +41,10 @@ parser.add_argument('-q, --quality', dest='quality', type=int, default=80,
                     help='specify JPEG lossy compression quality (50-150).  See man ddjvu for more information.')
 
 args = parser.parse_args()
+
+assert shutil.which('djvu2hocr'), 'dpsprep requires the djvu2hocr binary, which is part of ocradjvu'
+assert shutil.which('ddjvu') and shutil.which('djvused'), 'dpsprep requires the ddjvu and djvused binaries, which are part of djvulibre'
+assert shutil.which('pdftk'), 'dpsprep requires pdftk'
 
 if not os.path.exists(home + "/.dpsprep"):
     os.mkdir(home + "/.dpsprep")

--- a/dpsprep
+++ b/dpsprep
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # dpsprep - Sony Digital Paper DJVU to PDF converter
 # Copyright(c) 2015 Kevin Croker
 # GNU GPL v3

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,17 @@
+[[package]]
+name = "sexpdata"
+version = "0.0.3"
+description = "S-expression parser for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.3 | ^2.7"
+content-hash = "5f79e2aa49a1e55a062488f0f13bb26e0be063da0f1c28af857f5af8331c29ff"
+
+[metadata.files]
+sexpdata = [
+    {file = "sexpdata-0.0.3.tar.gz", hash = "sha256:1ac827a616c5e87ebb60fd6686fb86f8a166938c645f4089d92de3ffbdd494e0"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "dpsprep"
+version = "1.1.0"
+description = "A DJVU to PDF converter which preserves OCR text and bookmarks"
+authors = ["Kevin Arthur Schiff Croker"]
+license = "GPL-3.0-or-later"
+
+[tool.poetry.dependencies]
+python = "^3.3 | ^2.7"
+sexpdata = "^0.0.3"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Python 2 has been out of extended support for over a year and I did some minor changes so that the source is compatible with Python 3 (without breaking backward compatibility).

The changes are truly minor. I ran `2to3` on the source and it only replaced the print statements with calls to the print function. I also changed the binary to `python` since it is now compatible with both Python 2 and Python 3.

I added a [poetry](https://python-poetry.org/) file that lists sexpdata as a dependency. This can be used to publish `dpsprep` to [Pypi](https://pypi.org/) so that it can be installed via pip, poetry and other tools.

I cannot list binaries as dependencies, however I added checks for whether the required binaries (`djvu2hocr`, `ddjvu`, `ddjvused` and `pdftk`) are present.

There is also work done to port ocrodjvu to Python 3 (https://github.com/jwilk/ocrodjvu/issues/39), however `djvu2hocr` from ocrodjvu it is run as a binary and hence it is irrelevant what language it is written in.

I tested the script with several books and it did what it is intended to do.

Feel free to cherry-pick only the commits that seem meaningful to you.