### PR TITLE
Make the outline page translation more robust and configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You can also skip translating the text layer (it is sometimes not translated wel
 
     dpsprep --ocr '{"language": ["rus", "eng"]}' input.djvu
 
+You can also configure how the outline/toc page numbers in the djvu is translated to page numbers in pdf. Sometimes, their numbering convention is not consistent. For example, when converting djvu whose page numbers are one page ahead of the pdf:
+
+    dpsprep --toc-pg-offset=-1 input.djvu
+
 Consult the man file ([online](./dpsprep.1.ronn)) for details; there are a lot of options to consider.
 
 See the next section for different ways to run the program.

--- a/dpsprep.1.ronn
+++ b/dpsprep.1.ronn
@@ -17,7 +17,8 @@ This tool, initially made specifically for use with Sony's Digital Paper System 
 * `-w`, `--preserve-working`:  Preserve the working directory after script termination.
 * `-d`, `--delete-working`:    Delete any existing files in the working directory prior to writing to it.
 * `-t`, `--no-text`:           Disable the generation of text layers. Implied by --ocr.
-* `--ocr`                      Perform OCR via OCRmyPDF rather than trying to convert the text layer. If this parameter has a value, it should be a JSON dictionary of options to be passed to OCRmyPDF.
+* `--ocr`:                     Perform OCR via OCRmyPDF rather than trying to convert the text layer. If this parameter has a value, it should be a JSON dictionary of options to be passed to OCRmyPDF.
+* `--toc-pg-offset`:           Configure the page offset to be applied when translating outline/toc. This is to work with different djvu page numbering (starting from page 0 or page 1).
 * `-O1`:                       Use the lossless PDF image optimization from OCRmyPDF (without performing OCR).
 * `-O2`:                       Use the PDF image optimization from OCRmyPDF.
 * `-O3`:                       Use the aggressive lossy PDF image optimization from OCRmyPDF.

--- a/dpsprep/dpsprep.py
+++ b/dpsprep/dpsprep.py
@@ -79,9 +79,10 @@ def process_text(workdir: WorkingDirectory):
 @click.option('-p', '--pool-size', type=click.IntRange(min=0), default=4, help='Size of MultiProcessing pool for handling page-by-page operations.')
 @click.option('-q', '--quality', type=click.IntRange(min=0, max=100), default=75, help="Quality of images in output. Used only for JPEG compression, i.e. RGB and Grayscale images. Passed directly to Pillow and to OCRmyPDF's optimizer.")
 @click.option('--ocr', type=str, is_flag=False, flag_value='{}', help='Perform OCR via OCRmyPDF rather than trying to convert the text layer. If this parameter has a value, it should be a JSON dictionary of options to be passed to OCRmyPDF.')
+@click.option('--toc-pg-offset', type=int, default=-1, help='The page offset to be applied when translating outline/toc.')
 @click.argument('dest', type=click.Path(exists=False, resolve_path=True), required=False)
 @click.argument('src', type=click.Path(exists=True, resolve_path=True), required=True)
-@click.command()
+@click.command(context_settings={'show_default': True})
 def dpsprep(
     src: str,
     dest: Union[str, None],
@@ -94,6 +95,7 @@ def dpsprep(
     no_text: bool,
     optlevel: Union[int, None],
     ocr: Union[str, None],
+    toc_pg_offset: int,
 ):
     configure_loguru(verbose)
     workdir = WorkingDirectory(src, dest)
@@ -165,7 +167,7 @@ def dpsprep(
 
     if len(document.outline.sexpr) > 0:
         logger.info('Processing metadata.')
-        outline = OutlineTransformVisitor().visit(document.outline.sexpr)
+        outline = OutlineTransformVisitor(toc_pg_offset, len(document.pages)).visit(document.outline.sexpr)
         logger.info('Metadata processed.')
     else:
         logger.info('No metadata to process.')


### PR DESCRIPTION
Hi,

I encountered outline "page title" that the existing code could not recognize:
```
Could not determine page number from the page title #__sk_0000.djvu.
```

So I added a regex matching for the first consecutive number substring.

Also the page table translation rule is not the same neither. Existing code assumes the outline always start from page number 1 while for PDF the page number should start from 0.

This PR also introduced an option to config such outline translation page offset.