### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,19 @@ RUN apt-get update && apt-get install -y \
     libjpeg-dev \
     ghostscript \
     poppler-utils \
+    # Jbig2enc build requirements below
+    git autotools-dev automake libtool libleptonica-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# add Jbig2enc, after debian 13 is released, this can be removed (libjbig2enc-dev will be available)
+WORKDIR /opt
+RUN git clone https://github.com/agl/jbig2enc
+
+WORKDIR /opt/jbig2enc 
+RUN ./autogen.sh && ./configure && make install
+
+# Continue with environment setup 
 RUN pip install poetry
 RUN pip install ocrmypdf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,47 @@
-FROM python:3.9-bookworm
+# after Debian 13 (trixie) is released, this can be removed in favor of the libjbig2enc-dev package
+FROM debian:bookworm-slim AS jbig2enc-builder
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential autoconf automake libtool \
+    libleptonica-dev \
+    zlib1g-dev \
+    libffi-dev \
+    ca-certificates \
+    curl \
+    git \
+    libcairo2-dev \
+    pkg-config
+
+WORKDIR /opt
+
+RUN git clone --depth 1 https://github.com/agl/jbig2enc && \
+    cd jbig2enc && \
+    ./autogen.sh && \
+    ./configure && \
+    make && \
+    make install
+
+# The actual image to be used
+FROM python:3.11-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libdjvulibre-dev \
     libtiff-dev \
     libjpeg-dev \
     ghostscript \
     poppler-utils \
-    # Jbig2enc build requirements below
-    git autotools-dev automake libtool libleptonica-dev \
+    libleptonica-dev \
+    # libjbig2enc-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# add Jbig2enc, after debian 13 is released, this can be removed (libjbig2enc-dev will be available)
-WORKDIR /opt
-RUN git clone https://github.com/agl/jbig2enc
+COPY --from=jbig2enc-builder /usr/local/lib/ /usr/local/lib/
+COPY --from=jbig2enc-builder /usr/local/bin/ /usr/local/bin/
 
-WORKDIR /opt/jbig2enc 
-RUN ./autogen.sh && ./configure && make install
-
-# Continue with environment setup 
-RUN pip install poetry
-RUN pip install ocrmypdf
+RUN pip install --no-cache-dir poetry ocrmypdf
 
 WORKDIR /app
-COPY . /app/
+COPY . .
 
 RUN poetry config virtualenvs.create false \
     && poetry install --no-interaction --no-ansi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.9-bookworm
+
+RUN apt-get update && apt-get install -y \
+    libdjvulibre-dev \
+    libtiff-dev \
+    libjpeg-dev \
+    ghostscript \
+    poppler-utils \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install poetry
+RUN pip install ocrmypdf
+
+WORKDIR /app
+COPY . /app/
+
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi
+
+RUN mkdir /files
+
+WORKDIR /files
+
+ENTRYPOINT ["python", "-m", "dpsprep"]

--- a/README.md
+++ b/README.md
@@ -95,3 +95,33 @@ http://askubuntu.com/questions/46233/converting-djvu-to-pdf (OCR text transfer)
 
 By implementing the procedure of user pyrocrasty for extracting the outline, and putting it into the PDF generated above:
 http://superuser.com/questions/801893/converting-djvu-to-pdf-and-preserving-table-of-contents-how-is-it-possible (bookmark transfer)
+
+## Using Docker
+
+Build the Docker image:
+
+```bash
+docker build -t dpsprep .
+```
+
+Run the container with a volume mount to process files:
+
+```bash
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/files dpsprep input.djvu output.pdf
+```
+
+To use specific options:
+
+```bash
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/files dpsprep --pool=8 --quality=50 input.djvu output.pdf
+```
+
+### Add as alias
+
+Put the following line into `~/.bashrc` or `~/.zshrc`:
+
+```bash
+alias dpsprep='docker run --rm -u $(id -u):$(id -g) -v $(pwd):/files dpsprep'
+```
+
+This will allow you to run the command as `dpsprep` without needing to specify the Docker command each time.


### PR DESCRIPTION
This PR adds a Dockerfile for easier installation.

## Usage

Build the Docker image:
```
docker build -t dpsprep .
```

Run the container with a volume mount to process files:
```
docker run --rm -u $(id -u):$(id -g) -v $(pwd):/files dpsprep input.djvu output.pdf
```

To use specific options:
```
docker run --rm -u $(id -u):$(id -g) -v $(pwd):/files dpsprep --pool=8 --quality=50 input.djvu output.pdf
```