### PR TITLE
Improve usability via command-line options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,154 +12,154 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.5.4 - 2026-04-24
 
-* Run `uv` security audit and update some dependencies
+* Run `uv` security audit and update some dependencies.
 
 ## 2.5.3 - 2026-03-25
 
-* Fix broken workflow without text layer translation
-* Shorter names for temporary directories
-* Code maintenance
+* Fix broken workflow without text layer translation.
+* Shorter names for temporary directories.
+* Code maintenance.
 
 ## 2.5.2 - 2026-03-25
 
-* Relax dependency versions
+* Relax dependency versions.
 
 ## 2.5.1 - 2026-03-14
 
-* Allow manually configuring PDF page resolution (DPI)
+* Allow manually configuring PDF page resolution (DPI).
 
 ## 2.5.0 - 2026-03-13
 
-* Account for DjVu file resolution
-* Simplify image diffing and regenerate better-quality fixtures
+* Account for DjVu file resolution.
+* Simplify image diffing and regenerate better-quality fixtures.
 
 ## 2.4.2 - 2026-02-24
 
-* Fix issue where only the main process has its logger configured
+* Fix issue where only the main process has its logger configured.
 
 ## 2.4.1 - 2026-02-24
 
-* Fix compatibility issues with the new OCRmyPDF API
-* Remove support for Python 3.10
+* Fix compatibility issues with the new OCRmyPDF API.
+* Remove support for Python 3.10.
 
 ## 2.4.0 - 2026-02-24
 
-* Migrate to `uv` from `pyenv` + `poetry`
-* Update dependencies
+* Migrate to `uv` from `pyenv` + `poetry`.
+* Update dependencies.
 
 ## 2.3.1 - 2025-10-28
 
-* Fix mixed-up email format
+* Fix mixed-up email format.
 
 ## 2.3.0 - 2025-10-28
 
-* Remove support for Python 3.9
-* Migrate to standardized `pyproject.toml`
-* Update dependencies
+* Remove support for Python 3.9.
+* Migrate to standardized `pyproject.toml`.
+* Update dependencies.
 
 ## 2.2.15 - 2025-07-02
 
-* Add support for installation via `pipx`
+* Add support for installation via `pipx`.
 
 ## 2.2.14 - 2025-05-27
 
-* Improve installation notes
-* Bump djvulibre-python version
+* Improve installation notes.
+* Bump djvulibre-python version.
 
 ## 2.2.13 - 2025-02-12
 
-* Fail-safe quality settings for non-JPEG images
+* Fail-safe quality settings for non-JPEG images.
 
 ## 2.2.12 - 2025-01-27
 
-* Update pytest_image_diff and fix newly broken tests
+* Update pytest_image_diff and fix newly broken tests.
 
 ## 2.2.11 - 2025-01-26
 
-* Update dependencies
+* Update dependencies.
 
 ## 2.2.10 - 2024-10-25
 
-* Improve interface with OCRmyPDF
-* Fix CI build
+* Improve interface with OCRmyPDF.
+* Fix CI build.
 
 ## 2.2.9 - 2024-10-25
 
-* Improve type hints
-* Update dependencies
+* Improve type hints.
+* Update dependencies.
 
 ## 2.2.8 - 2024-10-18
 
-* Support single characters in the text layer
+* Support single characters in the text layer.
 
 ## 2.2.7 - 2024-08-27
 
-* Improve tab and newline handling
+* Improve tab and newline handling.
 
 ## 2.2.6 - 2024-08-05
 
-* Fix accidental whitespace removal from text blocks
+* Fix accidental whitespace removal from text blocks.
 
 ## 2.2.5 - 2024-07-20
 
-* Re-add ability to force the image mode (RGB/Grayscale/Monochrome)
+* Re-add ability to force the image mode (RGB/Grayscale/Monochrome).
 
 ## 2.2.4 - 2024-02-24
 
-* Update dependencies
+* Update dependencies.
 
 ## 2.2.3 - 2023-12-09
 
-* Fix CI build
-* Ignore invalid UTF-8 sequences
-* Ignore unrecognized page titles in the outline (#23)
+* Fix CI build.
+* Ignore invalid UTF-8 sequences.
+* Ignore unrecognized page titles in the outline (#23).
 
 ## 2.2.2 - 2023-10-29
 
-* Update dependencies
+* Update dependencies.
 
 ## 2.2.1 - 2023-11-06
 
-* Handle invalid PDF pages
-* Fix exception in text layer processing (#20)
+* Handle invalid PDF pages.
+* Fix exception in text layer processing (#20).
 
 ## 2.2.0 - 2023-10-28
 
-* Add options for disabling the text layer and for directly running OCR
+* Add options for disabling the text layer and for directly running OCR.
 
 ## 2.1.5 - 2023-10-27
 
-* Fix inverted colors in images (#16)
+* Fix inverted colors in images (#16).
 
 ## 2.1.4 - 2023-10-06
 
-* Fix typo in logging code
+* Fix typo in logging code.
 
 ## 2.1.3 - 2023-10-06
 
-* Improve logging
+* Improve logging.
 
 ## 2.1.2 - 2023-10-02
 
-* Accidental version bump
+* Accidental version bump.
 
 ## 2.1.1 - 2023-10-02
 
-* Remove debug code
+* Remove debug code.
 
 ## 2.1.0 - 2023-10-02
 
-* Add support for OCRmyPDF
+* Add support for OCRmyPDF.
 
 ## 2.0.2 - 2023-08-03
 
-* Update some other dependencies
-* Replace `python-djvulibre` with `djvulibre-python`
+* Update some other dependencies.
+* Replace `python-djvulibre` with `djvulibre-python`.
 
 ## 2.0.1 - 2023-06-22
 
-* Minor improvements in packaging
+* Minor improvements in packaging.
 
 ## 2.0.0 - 2023-05-04
 
-* Fully rewrite
+* Fully rewrite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Additions
 
-* Add a --socr ("streamlined" OCR) option that abbreviates `--ocr '{"language": ["eng", "grc"]}'` to `--ocrs eng,grc`
-* Add a -f short variant for --overwrite
+* Implement page ranges for `--mode`, `--dpi` and `--quality`.
+* Add a `--socr` ("streamlined" OCR) option that abbreviates `--ocr '{"language": ["eng", "grc"]}'` to `--ocrs eng,grc`.
+* Add a `-f` short variant for `--overwrite`.
 
 ### Changes
 
-* Deprecate the short overwrite flag -o in favor of -f
-* Warnings and errors are not logger to stderr
-* Restructure the code into smaller chunks
-* General maintenance work
+* Deprecate the short overwrite flag `-o` in favor of `-f`.
+* Warnings and errors are not logger to stderr.
+* Restructure the code into smaller chunks.
+* General maintenance work.
 
 ## 2.5.4 - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Additions
+
+* Add a -f short variant for --overwrite
+
+### Changes
+
+* Deprecate the short overwrite flag -o in favor of -f
+* Warnings and errors are not logger to stderr
 * Restructure the code into smaller chunks
 * General maintenance work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Additions
 
+* Add a --socr ("streamlined" OCR) option that abbreviates `--ocr '{"language": ["eng", "grc"]}'` to `--ocrs eng,grc`
 * Add a -f short variant for --overwrite
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ If you have [OCRmyPDF](https://github.com/ocrmypdf/OCRmyPDF) installed, you can 
 
     dpsprep -O3 input.djvu
 
-You can also skip translating the text layer (it is sometimes not translated well) and redo the OCR (rather than launching the `ocrmypdf` CLI, we use the API directly and accept options in JSON format):
+You can also skip translating the text layer (it is sometimes not being translated well) and redo the OCR (rather than launching the `ocrmypdf` CLI, we use the API directly and accept options in JSON format):
 
     dpsprep --socr rus,eng,grc input.djvu
 
-Consult the man file ([online](https://github.com/kcroker/dpsprep/wiki/dpsprep.1)) for details.
+Sometimes the pages of scanned books are saved as colorful images. For PDF, saving bitonal page backgrounds as RGB images can inflate the file by an order of magnitude (see [below](#compression)). We try to infer the color mode of each page, however that is sometimes inefficient. In such cases, we can force the color mode as follows:
+
+    dpsprep --mode bitonal input.djvu start.pdf
+
+In case we want to preserve the cover page as-is, we can use ranges:
+
+    dpsprep --mode bitonal[2-end] input.djvu start.pdf
+
+For details on these and other options, as well as the allowed range syntax, consult the man file ([online](https://github.com/kcroker/dpsprep/wiki/dpsprep.1)).
 
 ## Installation
 
@@ -85,6 +93,8 @@ If you want `dpsprep` to be able to use `ocrmypdf` from `pipx`'s isolated enviro
 ## Details
 
 ### Compression
+
+PDF files full of images cannot be compressed as efficiently as DjVu, leading to files that are hundreds of megabytes large. Fortunately, books are often bitonal, which allows for efficient compression like `group4` or `jbig2`. Unfortunately, in badly digitized books the scanned images may be saved as colorful JPEG files, which can partially be mitigated using `--mode bitonal` (possibly for only a range of pages).
 
 We perform compression in two stages:
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ If you have [OCRmyPDF](https://github.com/ocrmypdf/OCRmyPDF) installed, you can 
 
 You can also skip translating the text layer (it is sometimes not translated well) and redo the OCR (rather than launching the `ocrmypdf` CLI, we use the API directly and accept options in JSON format):
 
-    dpsprep --ocr '{"language": ["rus", "eng"]}' input.djvu
+    dpsprep --socr rus,eng,grc input.djvu
 
-Consult the man file ([online](https://github.com/kcroker/dpsprep/wiki/dpsprep.1)) for details; there are a lot of options.
-
-See the next section for different ways to run the program.
+Consult the man file ([online](https://github.com/kcroker/dpsprep/wiki/dpsprep.1)) for details.
 
 ## Installation
 

--- a/docs/examples.man
+++ b/docs/examples.man
@@ -12,9 +12,13 @@ Produce an output file using a large pool of workers:
 .IP
 dpsprep --pool=16 input.djvu
 .P
-Force bitonal images:
+Force all pages to be bitonal:
 .IP
 dpsprep --mode bitonal input.djvu
+.P
+Force bitonal pages but leave the cover page as-is (can be useful with badly digitized books):
+.IP
+dpsprep --mode bitonal[2-end] input.djvu
 .P
 Produce an output file by disregarding the text layer and running OCRmyPDF instead:
 .IP

--- a/docs/examples.man
+++ b/docs/examples.man
@@ -18,7 +18,7 @@ dpsprep --mode bitonal input.djvu
 .P
 Produce an output file by disregarding the text layer and running OCRmyPDF instead:
 .IP
-dpsprep --ocr '{"language": ["rus", "eng"]}' input.djvu
+dpsprep --socr rus,eng,grc input.djvu
 .P
 Simply disregard the text layer without OCR:
 .IP

--- a/src/dpsprep/cli.py
+++ b/src/dpsprep/cli.py
@@ -22,7 +22,8 @@ from dpsprep.workflow import attempt_to_optimize_result, combine_document, proce
 @click.option('-O1', 'optlevel', flag_value=1, help='Use the lossless PDF image optimization from OCRmyPDF (without performing OCR).')
 @click.option('-t', '--no-text', is_flag=True, help='Disable the generation of text layers. Implied by --ocr.')
 @click.option('-v', '--verbose', is_flag=True, help='Display debug messages.')
-@click.option('-o', '--overwrite', is_flag=True, help='Overwrite destination file.')
+@click.option('-o', 'deprecated_overwrite', is_flag=True, help='Deprecated flag for overwriting destination file. The short variant of --overwrite has been renamed to -f.')
+@click.option('-f', '--overwrite', is_flag=True, help='Overwrite destination file.')
 @click.option('-w', '--preserve-working', is_flag=True, help='Preserve the working directory after script termination.')
 @click.option('-d', '--delete-working', is_flag=True, help='Delete any existing files in the working directory prior to writing to it.')
 @click.version_option()
@@ -50,6 +51,17 @@ def dpsprep(
     The name comes from Sony's Digital Paper System (DPS), for which the tool was initially developed.
     """
     configure_loguru(verbose=verbose)
+
+    if deprecated_overwrite:
+        click.echo(
+            click.style(
+                'Warning: The short variant of --overwrite has been renamed from -o to -f. The -o flag will be removed in the next major release.',
+                fg='yellow',
+            ),
+            err=True,
+        )
+
+        overwrite = deprecated_overwrite
 
     try:
         ocr_options = parse_ocr_options(ocr)

--- a/src/dpsprep/cli.py
+++ b/src/dpsprep/cli.py
@@ -32,24 +32,24 @@ from dpsprep.workflow import attempt_to_optimize_result, combine_document, proce
 def dpsprep(
     src: str,
     dest: str | None,
-    quality: int | None,
-    dpi: int | None,
-    pool_size: int,
-    mode: ImageMode,
-    optlevel: int | None,
-    ocr: str | None,
-    verbose: bool,
-    overwrite: bool,
     delete_working: bool,
     preserve_working: bool,
+    overwrite: bool,
+    deprecated_overwrite: bool,
+    verbose: bool,
     no_text: bool,
+    optlevel: int | None,
+    pool_size: int,
+    quality: int | None,
+    mode: ImageMode,
+    dpi: int | None,
+    ocr: str | None,
 ) -> None:
     """Convert DjVu files to PDF.
 
     The name comes from Sony's Digital Paper System (DPS), for which the tool was initially developed.
     """
     configure_loguru(verbose=verbose)
-    workdir = WorkingDirectory(src, dest)
 
     try:
         ocr_options = parse_ocr_options(ocr)
@@ -69,6 +69,8 @@ def dpsprep(
         quality=quality,
         verbose=verbose,
     )
+
+    workdir = WorkingDirectory(src, dest)
 
     if not overwrite and workdir.dest.exists():
         raise SystemExit(f'File {workdir.dest} already exists.')

--- a/src/dpsprep/cli.py
+++ b/src/dpsprep/cli.py
@@ -5,18 +5,16 @@ import djvu.decode
 import loguru
 
 from dpsprep.exceptions import DpsPrepConfigError
-from dpsprep.images import ImageMode
 from dpsprep.logging import configure_loguru, human_readable_size
-from dpsprep.options import DpsPrepOptions, parse_ocr_options
+from dpsprep.options import parse_all_options
 from dpsprep.workdir import WorkingDirectory
 from dpsprep.workflow import attempt_to_optimize_result, combine_document, process_in_pool
 
 
-@click.option('--socr', type=str, is_flag=False, flag_value='{}', help='"Streamlined" OCR; `--ocrs eng,grc` expands to `--ocr \'{"language": ["eng", "grc"]}\'`.')
-@click.option('--ocr', type=str, is_flag=False, flag_value='{}', help='Perform OCR via OCRmyPDF rather than trying to convert the text layer. If this parameter has a value, it should be a JSON dictionary of options to be passed to OCRmyPDF.')
-@click.option('--dpi', type=click.IntRange(min=1), help='Override DPI values encoded in the DjVu file for individual pages.')
-@click.option('-m', '--mode', type=click.Choice(['infer', 'bitonal', 'grayscale', 'rgb']), default='infer', help='Override the image modes encoded in the DjVu file for individual pages. It sometimes makes sense to force bitonal images since they compress well.')
-@click.option('-q', '--quality', type=click.IntRange(min=0, max=100), help="Quality of images in output. Used only for JPEG compression, i.e. RGB and Grayscale images. Passed directly to Pillow and to OCRmyPDF's optimizer.")
+# OCR options
+@click.option('--socr', type=str, default=None, help='"Streamlined" OCR; `--ocrs eng,grc` expands to `--ocr \'{"language": ["eng", "grc"]}\'`.')
+@click.option('--ocr', type=str, default=None, help='Perform OCR via OCRmyPDF rather than trying to convert the text layer. If this parameter has a value, it should be a JSON dictionary of options to be passed to OCRmyPDF.')
+# Other options
 @click.option('-p', '--pool-size', type=click.IntRange(min=0), default=4, help='Size of MultiProcessing pool for handling page-by-page operations.')
 @click.option('-O3', 'optlevel', flag_value=3, help='Use the aggressive lossy PDF image optimization from OCRmyPDF.')
 @click.option('-O2', 'optlevel', flag_value=2, help='Use the PDF image optimization from OCRmyPDF.')
@@ -27,13 +25,23 @@ from dpsprep.workflow import attempt_to_optimize_result, combine_document, proce
 @click.option('-f', '--overwrite', is_flag=True, help='Overwrite destination file.')
 @click.option('-w', '--preserve-working', is_flag=True, help='Preserve the working directory after script termination.')
 @click.option('-d', '--delete-working', is_flag=True, help='Delete any existing files in the working directory prior to writing to it.')
+# Range options
+@click.option('-q', '--quality', type=str, default='', help="A range group option that determines the quality of images in output. Valid values range between 1 and 100. Used only for JPEG compression, i.e. RGB and Grayscale images. Passed directly to Pillow and to OCRmyPDF's optimizer.")
+@click.option('--dpi', type=str, default='', help='A range group option that allows overriding DPI values encoded in the DjVu file for individual pages.')
+@click.option('-m', '--mode', type=str, default='infer', help='A range group option that allows overriding the image modes encoded in the DjVu file for individual pages.  Valid values are `infer` (default), `bitonal`, `grayscale` and `rgb`. It sometimes makes sense to force bitonal images since they compress well.')
 @click.version_option()
 @click.argument('dest', type=click.Path(exists=False, resolve_path=True), required=False)
 @click.argument('src', type=click.Path(exists=True, resolve_path=True), required=True)
 @click.command(epilog='See dpsprep(1) for more details.')
 def dpsprep(
+    # Positional arguments
     src: str,
     dest: str | None,
+    # Range options
+    mode: str,
+    dpi: str,
+    quality: str,
+    # Other options
     delete_working: bool,
     preserve_working: bool,
     overwrite: bool,
@@ -42,15 +50,18 @@ def dpsprep(
     no_text: bool,
     optlevel: int | None,
     pool_size: int,
-    quality: int | None,
-    mode: ImageMode,
-    dpi: int | None,
+    # OCR options
     ocr: str | None,
     socr: str | None,
 ) -> None:
     """Convert DjVu files to PDF.
 
     The name comes from Sony's Digital Paper System (DPS), for which the tool was initially developed.
+
+    The usage should be straightforward, however the options that accept page ranges require some
+    elaboration. For example, the --mode option accepts the following values:
+
+        `rgb`, `rgb[3]`, `rgb[3-4]`, `rgb[3-end]`, `rgb[3],rgb[10-end]`
     """
     configure_loguru(verbose=verbose)
 
@@ -66,28 +77,24 @@ def dpsprep(
         overwrite = deprecated_overwrite
 
     try:
-        ocr_options = parse_ocr_options(ocr, socr)
+        options = parse_all_options(
+            ocr=ocr,
+            socr=socr,
+            mode=mode,
+            dpi=dpi,
+            quality=quality,
+            no_text=no_text,
+            pool_size=pool_size,
+            verbose=verbose,
+            optlevel=optlevel,
+        )
     except DpsPrepConfigError as err:
-        raise SystemExit(str(err)) from err
-
-    if ocr_options:
-        no_text = True
-
-    options = DpsPrepOptions(
-        dpi=dpi,
-        mode=mode,
-        no_text=no_text,
-        ocr_options=ocr_options,
-        optlevel=optlevel,
-        pool_size=pool_size,
-        quality=quality,
-        verbose=verbose,
-    )
+        raise click.ClickException(str(err)) from err
 
     workdir = WorkingDirectory(src, dest)
 
     if not overwrite and workdir.dest.exists():
-        raise SystemExit(f'File {workdir.dest} already exists.')
+        raise click.ClickException(f'File {workdir.dest} already exists.')
 
     start_time = time()
 

--- a/src/dpsprep/cli.py
+++ b/src/dpsprep/cli.py
@@ -12,6 +12,7 @@ from dpsprep.workdir import WorkingDirectory
 from dpsprep.workflow import attempt_to_optimize_result, combine_document, process_in_pool
 
 
+@click.option('--socr', type=str, is_flag=False, flag_value='{}', help='"Streamlined" OCR; `--ocrs eng,grc` expands to `--ocr \'{"language": ["eng", "grc"]}\'`.')
 @click.option('--ocr', type=str, is_flag=False, flag_value='{}', help='Perform OCR via OCRmyPDF rather than trying to convert the text layer. If this parameter has a value, it should be a JSON dictionary of options to be passed to OCRmyPDF.')
 @click.option('--dpi', type=click.IntRange(min=1), help='Override DPI values encoded in the DjVu file for individual pages.')
 @click.option('-m', '--mode', type=click.Choice(['infer', 'bitonal', 'grayscale', 'rgb']), default='infer', help='Override the image modes encoded in the DjVu file for individual pages. It sometimes makes sense to force bitonal images since they compress well.')
@@ -45,6 +46,7 @@ def dpsprep(
     mode: ImageMode,
     dpi: int | None,
     ocr: str | None,
+    socr: str | None,
 ) -> None:
     """Convert DjVu files to PDF.
 
@@ -64,7 +66,7 @@ def dpsprep(
         overwrite = deprecated_overwrite
 
     try:
-        ocr_options = parse_ocr_options(ocr)
+        ocr_options = parse_ocr_options(ocr, socr)
     except DpsPrepConfigError as err:
         raise SystemExit(str(err)) from err
 

--- a/src/dpsprep/cli.py
+++ b/src/dpsprep/cli.py
@@ -71,8 +71,7 @@ def dpsprep(
     )
 
     if not overwrite and workdir.dest.exists():
-        msg = f'File {workdir.dest} already exists.'
-        raise SystemExit(msg)
+        raise SystemExit(f'File {workdir.dest} already exists.')
 
     start_time = time()
 

--- a/src/dpsprep/cli.py
+++ b/src/dpsprep/cli.py
@@ -4,16 +4,25 @@ import click
 import djvu.decode
 import loguru
 
-from dpsprep.exceptions import DpsPrepConfigError
 from dpsprep.logging import configure_loguru, human_readable_size
-from dpsprep.options import parse_all_options
+from dpsprep.options import (
+    DpiOverridesClickType,
+    DpsPrepOptions,
+    ImageMode,
+    ImageModeOverridesClickType,
+    JsonObject,
+    OcrOptionClickType,
+    QualityOverridesClickType,
+    SocrOptionClickType,
+)
+from dpsprep.ranges import RangeOptionGroup
 from dpsprep.workdir import WorkingDirectory
 from dpsprep.workflow import attempt_to_optimize_result, combine_document, process_in_pool
 
 
 # OCR options
-@click.option('--socr', type=str, default=None, help='"Streamlined" OCR; `--ocrs eng,grc` expands to `--ocr \'{"language": ["eng", "grc"]}\'`.')
-@click.option('--ocr', type=str, default=None, help='Perform OCR via OCRmyPDF rather than trying to convert the text layer. If this parameter has a value, it should be a JSON dictionary of options to be passed to OCRmyPDF.')
+@click.option('--socr', 'socr_options', type=SocrOptionClickType(), default=None, help='"Streamlined" OCR; `--ocrs eng,grc` expands to `--ocr \'{"language": ["eng", "grc"]}\'`.')
+@click.option('--ocr', 'ocr_options', type=OcrOptionClickType(), default=None, help='Perform OCR via OCRmyPDF rather than trying to convert the text layer. If this parameter has a value, it should be a JSON dictionary of options to be passed to OCRmyPDF.')
 # Other options
 @click.option('-p', '--pool-size', type=click.IntRange(min=0), default=4, help='Size of MultiProcessing pool for handling page-by-page operations.')
 @click.option('-O3', 'optlevel', flag_value=3, help='Use the aggressive lossy PDF image optimization from OCRmyPDF.')
@@ -26,9 +35,9 @@ from dpsprep.workflow import attempt_to_optimize_result, combine_document, proce
 @click.option('-w', '--preserve-working', is_flag=True, help='Preserve the working directory after script termination.')
 @click.option('-d', '--delete-working', is_flag=True, help='Delete any existing files in the working directory prior to writing to it.')
 # Range options
-@click.option('-q', '--quality', type=str, default='', help="A range group option that determines the quality of images in output. Valid values range between 1 and 100. Used only for JPEG compression, i.e. RGB and Grayscale images. Passed directly to Pillow and to OCRmyPDF's optimizer.")
-@click.option('--dpi', type=str, default='', help='A range group option that allows overriding DPI values encoded in the DjVu file for individual pages.')
-@click.option('-m', '--mode', type=str, default='infer', help='A range group option that allows overriding the image modes encoded in the DjVu file for individual pages.  Valid values are `infer` (default), `bitonal`, `grayscale` and `rgb`. It sometimes makes sense to force bitonal images since they compress well.')
+@click.option('-q', '--quality', 'quality_overrides', type=QualityOverridesClickType(), default='', help="Determine the quality of images in output. Valid values range between 1 and 100. Used only for JPEG compression, i.e. RGB and Grayscale images. Passed directly to Pillow and to OCRmyPDF's optimizer.")
+@click.option('--dpi', 'dpi_overrides', type=DpiOverridesClickType(), default='', help='Override the DPI values encoded in the DjVu file for individual pages.')
+@click.option('-m', '--mode', 'mode_overrides', type=ImageModeOverridesClickType(), default='infer', help='Override the image modes encoded in the DjVu file for individual pages. Valid values are `infer` (default), `bitonal`, `grayscale` and `rgb`. It sometimes makes sense to force bitonal images since they compress well.')
 @click.version_option()
 @click.argument('dest', type=click.Path(exists=False, resolve_path=True), required=False)
 @click.argument('src', type=click.Path(exists=True, resolve_path=True), required=True)
@@ -38,9 +47,9 @@ def dpsprep(
     src: str,
     dest: str | None,
     # Range options
-    mode: str,
-    dpi: str,
-    quality: str,
+    mode_overrides: RangeOptionGroup[ImageMode],
+    dpi_overrides: RangeOptionGroup[int],
+    quality_overrides: RangeOptionGroup[int],
     # Other options
     delete_working: bool,
     preserve_working: bool,
@@ -51,8 +60,8 @@ def dpsprep(
     optlevel: int | None,
     pool_size: int,
     # OCR options
-    ocr: str | None,
-    socr: str | None,
+    ocr_options: JsonObject | None,
+    socr_options: JsonObject | None,
 ) -> None:
     """Convert DjVu files to PDF.
 
@@ -76,20 +85,19 @@ def dpsprep(
 
         overwrite = deprecated_overwrite
 
-    try:
-        options = parse_all_options(
-            ocr=ocr,
-            socr=socr,
-            mode=mode,
-            dpi=dpi,
-            quality=quality,
-            no_text=no_text,
-            pool_size=pool_size,
-            verbose=verbose,
-            optlevel=optlevel,
-        )
-    except DpsPrepConfigError as err:
-        raise click.ClickException(str(err)) from err
+    if ocr_options and socr_options:
+        raise click.ClickException('Cannot specify both --ocr and -socr simultaneously.')
+
+    options = DpsPrepOptions(
+        mode_overrides=mode_overrides,
+        dpi_overrides=dpi_overrides,
+        quality_overrides=quality_overrides,
+        no_text=no_text or bool(ocr_options or socr_options),
+        ocr_options=ocr_options or socr_options,
+        optlevel=optlevel,
+        pool_size=pool_size,
+        verbose=verbose,
+    )
 
     workdir = WorkingDirectory(src, dest)
 

--- a/src/dpsprep/images.py
+++ b/src/dpsprep/images.py
@@ -1,13 +1,12 @@
 import pathlib
-from typing import Literal, NamedTuple
+from typing import NamedTuple
 
 import djvu.decode
 import loguru
 import PIL.features
 from PIL import Image, ImageOps
 
-
-ImageMode = Literal['rgb', 'grayscale', 'bitonal', 'infer']
+from dpsprep.options import DpsPrepOptions, ImageMode
 
 
 djvu_pixel_formats = {
@@ -32,6 +31,7 @@ pil_modes = {
 class ProcessedPageBackground(NamedTuple):
     pil_image: Image.Image
     resolution: int
+    mode: ImageMode
 
 
 def process_djvu_page(page: djvu.decode.Page, mode: ImageMode, i: int) -> ProcessedPageBackground:
@@ -67,7 +67,7 @@ def process_djvu_page(page: djvu.decode.Page, mode: ImageMode, i: int) -> Proces
             1,
         )
 
-        return ProcessedPageBackground(image, page_job.dpi)
+        return ProcessedPageBackground(image, page_job.dpi, 'bitonal')
 
     image = Image.frombuffer(
         pil_modes[mode],
@@ -81,10 +81,14 @@ def process_djvu_page(page: djvu.decode.Page, mode: ImageMode, i: int) -> Proces
         # See also https://github.com/kcroker/dpsprep/issues/16
         ImageOps.invert(image) if mode == 'bitonal' else image,
         page_job.dpi,
+        mode,
     )
 
 
-def failsafe_save_djvu_page(page_bg: ProcessedPageBackground, target: pathlib.Path, quality: int | None, dpi: int | None, page_number: int) -> None:
+def failsafe_save_djvu_page(page_bg: ProcessedPageBackground, target: pathlib.Path, options: DpsPrepOptions, i: int) -> None:
+    quality = options.quality_overrides.get_value_for_zero_based_page(i)
+    dpi = options.dpi_overrides.get_value_for_zero_based_page(i) or page_bg.resolution
+
     if quality is not None:
         if page_bg.pil_image.mode in pil_modes['bitonal'] and PIL.features.check_codec('libtiff'):
             loguru.logger.warning('Pillow uses TIFF for encoding bitonal PDF images. The encoder does not support a "quality" setting. If the conversion fails, please try again without specifying quality.')
@@ -94,15 +98,15 @@ def failsafe_save_djvu_page(page_bg: ProcessedPageBackground, target: pathlib.Pa
                 target,
                 format='PDF',
                 quality=quality,
-                resolution=dpi or page_bg.resolution,
+                resolution=dpi,
             )
         except ValueError:
-            loguru.logger.warning(f'Failed to encode page {page_number}. Trying again without setting quality.')
+            loguru.logger.warning(f'Failed to encode page {i}. Trying again without setting quality.')
         else:
             return
 
     page_bg.pil_image.save(
         target,
         format='PDF',
-        resolution=dpi or page_bg.resolution,
+        resolution=dpi,
     )

--- a/src/dpsprep/logging.py
+++ b/src/dpsprep/logging.py
@@ -1,24 +1,30 @@
-import os
 import sys
-from types import TracebackType
 
 import loguru
 
 
-cached_stdout = sys.stdout
+LOGURU_FORMAT = '<level>{level}</level> <green>{time:HH:mm:ss}</green> <level>{message}</level>'
+LOGURU_WARNING_LEVEL = 30
 
 
 def configure_loguru(*, verbose: bool) -> None:
     loguru.logger.remove()
+
     loguru.logger.add(
-        cached_stdout,
-        format='<level>{level}</level> <green>{time:HH:mm:ss}</green> <level>{message}</level>',
+        sys.stderr,
+        format=LOGURU_FORMAT,
+        level='WARNING',
+    )
+
+    loguru.logger.add(
+        sys.stdout,
+        filter=lambda record: record['level'].no < LOGURU_WARNING_LEVEL,
+        format=LOGURU_FORMAT,
         level='DEBUG' if verbose else 'INFO',
     )
 
 
 def human_readable_size(size: int) -> str:
-    # ruff: disable[PLR2004]
     if size < 1024:
         return f'{size} bytes'
 
@@ -26,20 +32,3 @@ def human_readable_size(size: int) -> str:
         return f'{size / 1024:.02f} KiB'
 
     return f'{size / 1024 ** 2:.02f} MiB'
-    # ruff: enable[PLR2004]
-
-
-# img2pdf abuses debug logging by using print
-# This is a way to temporarily silence it
-class SilencePrint:
-    def __enter__(self) -> None:
-        sys.stdout = open(os.devnull, 'w', encoding='utf-8')
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-     ) -> None:
-        sys.stdout.close()
-        sys.stdout = cached_stdout

--- a/src/dpsprep/ocrmypdf_adapter.py
+++ b/src/dpsprep/ocrmypdf_adapter.py
@@ -10,7 +10,7 @@ import shutil
 
 import loguru
 
-from dpsprep.options import DpsPrepOptions, Json
+from dpsprep.options import DpsPrepOptions, JsonObject
 from dpsprep.workdir import WorkingDirectory
 
 
@@ -57,7 +57,7 @@ def run_ocrmypdf_optimizer(workdir: WorkingDirectory, options: DpsPrepOptions) -
     return True
 
 
-def perform_ocr(workdir: WorkingDirectory, options: Json) -> bool:
+def perform_ocr(workdir: WorkingDirectory, options: JsonObject) -> bool:
     try:
         from ocrmypdf import api
     except ImportError:

--- a/src/dpsprep/ocrmypdf_adapter.py
+++ b/src/dpsprep/ocrmypdf_adapter.py
@@ -27,6 +27,8 @@ def run_ocrmypdf_optimizer(workdir: WorkingDirectory, options: DpsPrepOptions) -
         loguru.logger.warning('Cannot detect OCRmyPDF. No optimizations will be performed on the output file.')
         return False
 
+    quality = options.quality_overrides.get_global_value()
+
     omp_options = OcrOptions(
         input_file=workdir.combined_pdf_without_text_path,
         output_file=workdir.combined_pdf_path,
@@ -34,8 +36,8 @@ def run_ocrmypdf_optimizer(workdir: WorkingDirectory, options: DpsPrepOptions) -
         jobs=options.pool_size,
         optimize=options.optlevel,
         # When set to 0, OCRmyPDF's "optimize" function attempts to adjust them
-        jpg_quality=options.quality or 0,
-        png_quality=options.quality or 0,
+        jpg_quality=quality or 0,
+        png_quality=quality or 0,
     )
 
     info = PdfInfo(workdir.combined_pdf_path)

--- a/src/dpsprep/options.py
+++ b/src/dpsprep/options.py
@@ -1,26 +1,37 @@
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal, cast, get_args
 
 from dpsprep.exceptions import DpsPrepConfigError
-from dpsprep.images import ImageMode
+from dpsprep.ranges import (
+    RangeOptionGroup,
+    parse_int_range_group_option,
+    parse_str_range_group_option,
+)
 
 
 # I have implemented better JSON types elsewhere, but here there is no point to do so.
 Json = Mapping[str, Any]
+ImageMode = Literal['rgb', 'grayscale', 'bitonal', 'infer']
+IMAGE_MODES = get_args(ImageMode)
+
+DEFAULT_IMAGE_MODE: ImageMode = 'infer'
 
 
 @dataclass(frozen=True)
 class DpsPrepOptions:
-    mode: ImageMode
+    # Range options
+    mode_overrides: RangeOptionGroup[ImageMode]
+    dpi_overrides: RangeOptionGroup[int]
+    quality_overrides: RangeOptionGroup[int]
+
+    # Other options
     no_text: bool
     pool_size: int
     verbose: bool
-    dpi: int | None
     ocr_options: Json | None
     optlevel: int | None
-    quality: int | None
 
 
 def parse_ocr_options(ocr_str: str | None, socr_str: str | None) -> Json | None:
@@ -42,3 +53,66 @@ def parse_ocr_options(ocr_str: str | None, socr_str: str | None) -> Json | None:
         raise DpsPrepConfigError(f'The OCR option string {ocr_str!r} must be a JSON object.')
 
     return options
+
+
+def parse_mode_option(string: str) -> RangeOptionGroup[ImageMode]:
+    group = parse_str_range_group_option(string)
+
+    for range_ in group.ranges:
+        if range_.value not in IMAGE_MODES:
+            raise DpsPrepConfigError(f'Invalid image mode {range_.value}')
+
+    return cast('RangeOptionGroup[ImageMode]', group)
+
+
+def parse_dpi_option(string: str) -> RangeOptionGroup[int]:
+    group = parse_int_range_group_option(string)
+
+    for range_ in group.ranges:
+        if range_.value < 1:
+            raise DpsPrepConfigError(f'Invalid DPI {range_.value}')
+
+    return group
+
+
+def parse_quality_option(string: str) -> RangeOptionGroup[int]:
+    group = parse_int_range_group_option(string)
+
+    for range_ in group.ranges:
+        if not 1 <= range_.value <= 100:
+            raise DpsPrepConfigError(f'Expected quality option to be between 1 and 100, but got {range_.value}')
+
+    return group
+
+
+def parse_all_options(
+    # Options that need parsing
+    ocr: str | None,
+    socr: str | None,
+    mode: str,
+    dpi: str,
+    quality: str,
+
+    # Options that don't need parsing
+    no_text: bool,
+    pool_size: int,
+    verbose: bool,
+    optlevel: int | None,
+) -> DpsPrepOptions:
+    ocr_options = parse_ocr_options(ocr, socr)
+
+    if ocr_options:
+        no_text = True
+
+    return DpsPrepOptions(
+        mode_overrides=parse_mode_option(mode),
+        dpi_overrides=parse_dpi_option(dpi),
+        quality_overrides=parse_quality_option(quality),
+
+        no_text=no_text,
+        ocr_options=ocr_options,
+        optlevel=optlevel,
+        pool_size=pool_size,
+        verbose=verbose,
+    )
+

--- a/src/dpsprep/options.py
+++ b/src/dpsprep/options.py
@@ -1,18 +1,22 @@
 import json
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, cast, get_args
 
+import click
+from typing_extensions import override
+
 from dpsprep.exceptions import DpsPrepConfigError
 from dpsprep.ranges import (
+    RangeOption,
     RangeOptionGroup,
-    parse_int_range_group_option,
-    parse_str_range_group_option,
+    parse_int_range_option,
+    parse_str_range_option,
 )
 
 
 # I have implemented better JSON types elsewhere, but here there is no point to do so.
-Json = Mapping[str, Any]
+JsonObject = Mapping[str, Any]
 ImageMode = Literal['rgb', 'grayscale', 'bitonal', 'infer']
 IMAGE_MODES = get_args(ImageMode)
 
@@ -30,11 +34,11 @@ class DpsPrepOptions:
     no_text: bool
     pool_size: int
     verbose: bool
-    ocr_options: Json | None
+    ocr_options: JsonObject | None
     optlevel: int | None
 
 
-def parse_ocr_options(ocr_str: str | None, socr_str: str | None) -> Json | None:
+def parse_ocr_options(ocr_str: str | None, socr_str: str | None) -> JsonObject | None:
     if socr_str is not None:
         if ocr_str is not None:
             raise DpsPrepConfigError('Cannot specify both --ocr and -socr simultaneously.')
@@ -55,64 +59,109 @@ def parse_ocr_options(ocr_str: str | None, socr_str: str | None) -> Json | None:
     return options
 
 
-def parse_mode_option(string: str) -> RangeOptionGroup[ImageMode]:
-    group = parse_str_range_group_option(string)
+class OcrOptionClickType(click.ParamType):
+    name = 'JSON object'
 
-    for range_ in group.ranges:
-        if range_.value not in IMAGE_MODES:
-            raise DpsPrepConfigError(f'Invalid image mode {range_.value}')
+    @override
+    def convert(self, value: str | JsonObject | None, param: click.Parameter | None, ctx: click.Context | None) -> JsonObject | None:
+        if value is None:
+            return None
 
-    return cast('RangeOptionGroup[ImageMode]', group)
+        if isinstance(value, Mapping):
+            return value
 
+        try:
+            ocr_options = json.loads(value)
+        except ValueError:
+            self.fail(f'The OCR option string {value!r} must be a JSON object.', param, ctx)
 
-def parse_dpi_option(string: str) -> RangeOptionGroup[int]:
-    group = parse_int_range_group_option(string)
+        if not isinstance(ocr_options, dict):
+            self.fail(f'The OCR option string {value!r} must be a JSON object.', param, ctx)
 
-    for range_ in group.ranges:
-        if range_.value < 1:
-            raise DpsPrepConfigError(f'Invalid DPI {range_.value}')
-
-    return group
-
-
-def parse_quality_option(string: str) -> RangeOptionGroup[int]:
-    group = parse_int_range_group_option(string)
-
-    for range_ in group.ranges:
-        if not 1 <= range_.value <= 100:
-            raise DpsPrepConfigError(f'Expected quality option to be between 1 and 100, but got {range_.value}')
-
-    return group
+        return ocr_options
 
 
-def parse_all_options(
-    # Options that need parsing
-    ocr: str | None,
-    socr: str | None,
-    mode: str,
-    dpi: str,
-    quality: str,
+class SocrOptionClickType(click.ParamType):
+    name = 'comma-separated languages'
 
-    # Options that don't need parsing
-    no_text: bool,
-    pool_size: int,
-    verbose: bool,
-    optlevel: int | None,
-) -> DpsPrepOptions:
-    ocr_options = parse_ocr_options(ocr, socr)
+    @override
+    def convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> JsonObject | None:
+        return dict(languages=value.split(','))
 
-    if ocr_options:
-        no_text = True
 
-    return DpsPrepOptions(
-        mode_overrides=parse_mode_option(mode),
-        dpi_overrides=parse_dpi_option(dpi),
-        quality_overrides=parse_quality_option(quality),
+class ImageModeOverridesClickType(click.ParamType):
+    name = 'comma-separated image modes with page ranges'
 
-        no_text=no_text,
-        ocr_options=ocr_options,
-        optlevel=optlevel,
-        pool_size=pool_size,
-        verbose=verbose,
-    )
+    def _iter_convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> Iterator[RangeOption[ImageMode]]:
+        if value == '':
+            return
 
+        for segment in value.split(','):
+            try:
+                option = parse_str_range_option(segment)
+            except DpsPrepConfigError as err:
+                self.fail(str(err), param, ctx)
+
+            if option.value not in IMAGE_MODES:
+                self.fail(f'Expected one of {", ".join(IMAGE_MODES)}, but got {option.value}', param, ctx)
+
+            yield cast('RangeOption[ImageMode]', option)
+
+    @override
+    def convert(self, value: RangeOptionGroup[ImageMode] | str, param: click.Parameter | None, ctx: click.Context | None) -> RangeOptionGroup[ImageMode]:
+        if isinstance(value, RangeOptionGroup):
+            return value
+
+        return RangeOptionGroup(list(self._iter_convert(value, param, ctx)))
+
+
+class DpiOverridesClickType(click.ParamType):
+    name = 'comma-separated integers with page ranges'
+
+    def _iter_convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> Iterator[RangeOption[int]]:
+        if value == '':
+            return
+
+        for segment in value.split(','):
+            try:
+                option = parse_int_range_option(segment)
+            except DpsPrepConfigError as err:
+                self.fail(str(err), param, ctx)
+
+            if option.value < 1:
+                self.fail(f'Expected a positive DPI, but got {option.value}', param, ctx)
+
+            yield option
+
+    @override
+    def convert(self, value: RangeOptionGroup[int] | str, param: click.Parameter | None, ctx: click.Context | None) -> RangeOptionGroup[int]:
+        if isinstance(value, RangeOptionGroup):
+            return value
+
+        return RangeOptionGroup(list(self._iter_convert(value, param, ctx)))
+
+
+class QualityOverridesClickType(click.ParamType):
+    name = 'comma-separated integers with page ranges'
+
+    def _iter_convert(self, value: str, param: click.Parameter | None, ctx: click.Context | None) -> Iterator[RangeOption[int]]:
+        if value == '':
+            return
+
+        for segment in value.split(','):
+            try:
+                option = parse_int_range_option(segment)
+            except DpsPrepConfigError as err:
+                self.fail(str(err), param, ctx)
+
+            if not 1 <= option.value <= 100:
+                self.fail(f'Expected quality option to be between 1 and 100, but got {option.value}', param, ctx)
+
+            yield option
+
+    @override
+    def convert(self, value: RangeOptionGroup[int] | str, param: click.Parameter | None, ctx: click.Context | None) -> RangeOptionGroup[int]:
+        if isinstance(value, RangeOptionGroup):
+            return value
+
+        return RangeOptionGroup(list(self._iter_convert(value, param, ctx)))

--- a/src/dpsprep/options.py
+++ b/src/dpsprep/options.py
@@ -23,7 +23,13 @@ class DpsPrepOptions:
     quality: int | None
 
 
-def parse_ocr_options(ocr_str: str | None) -> Json | None:
+def parse_ocr_options(ocr_str: str | None, socr_str: str | None) -> Json | None:
+    if socr_str is not None:
+        if ocr_str is not None:
+            raise DpsPrepConfigError('Cannot specify both --ocr and -socr simultaneously.')
+
+        return dict(languages=socr_str.split(','))
+
     if ocr_str is None:
         return None
 

--- a/src/dpsprep/outline/text.py
+++ b/src/dpsprep/outline/text.py
@@ -9,6 +9,8 @@ import djvu.sexpr
 import loguru
 from fpdf import FPDF
 
+from dpsprep.options import DpsPrepOptions
+
 from .sexpr_visitor import SExpressionVisitor
 
 
@@ -163,7 +165,7 @@ class TextDrawVisitor(SExpressionVisitor):
     visit_list_region = visit_list_column
 
 
-def extract_text_as_fpdf(document: djvu.decode.Document, dpi: int | None) -> FPDF:
+def extract_text_as_fpdf(document: djvu.decode.Document, options: DpsPrepOptions) -> FPDF:
     pdf = FPDF(unit='in')
     pdf.add_font(
         family='Invisible',
@@ -173,7 +175,7 @@ def extract_text_as_fpdf(document: djvu.decode.Document, dpi: int | None) -> FPD
 
     for i, page in enumerate(document.pages):
         page_job = page.decode(wait=True)
-        page_dpi = dpi or page_job.dpi
+        page_dpi = options.dpi_overrides.get_value_for_zero_based_page(i) or page_job.dpi
         pdf.add_page(format=(page_job.width / page_dpi, page_job.height / page_dpi))
         loguru.logger.debug(f'Processing text for page {i + 1}.')
         visitor = TextDrawVisitor(pdf, page_dpi)

--- a/src/dpsprep/ranges.py
+++ b/src/dpsprep/ranges.py
@@ -28,17 +28,15 @@ class RangeOption(Generic[T]):
     start: int | None = None
     end: int | None = None
 
-    def matches_zero_based_page(self, i: int) -> bool:
-        one_based = i + 1
-
+    def matches_one_based_page(self, page_number: int) -> bool:
         if self.start is not None and self.end is not None:
-            return self.start <= one_based <= self.end
+            return self.start <= page_number <= self.end
 
         if self.start is not None:
-            return one_based >= self.start
+            return page_number >= self.start
 
         if self.end is not None:
-            return one_based <= self.end
+            return page_number <= self.end
 
         return True
 
@@ -47,12 +45,15 @@ class RangeOption(Generic[T]):
 class RangeOptionGroup(Generic[T]):
     ranges: Sequence[RangeOption[T]]
 
-    def get_value_for_zero_based_page(self, i: int) -> T | None:
+    def get_value_for_one_based_page(self, page_number: int) -> T | None:
         for range_ in self.ranges:
-            if range_.matches_zero_based_page(i):
+            if range_.matches_one_based_page(page_number):
                 return range_.value
 
         return None
+
+    def get_value_for_zero_based_page(self, i: int) -> T | None:
+        return self.get_value_for_one_based_page(i + 1)
 
     def get_global_value(self) -> T | None:
         if len(self.ranges) == 1 and self.ranges[0].start == self.ranges[0].end is None:
@@ -66,14 +67,14 @@ def parse_str_range_option(string: str) -> RangeOption[str]:
 
     if match is None:
         if '[' in string:
-            raise DpsPrepConfigError(f'Invalid range option {string}')
+            raise DpsPrepConfigError(f'Incomplete range option {string}')
 
         return RangeOption(string)
 
     groups = match.groupdict()
 
     if groups.get('tail'):
-        raise DpsPrepConfigError(f'Unexpected content after slice in range option {string}')
+        raise DpsPrepConfigError(f'Unexpected content after range in option {string}')
 
     value: Any
 
@@ -94,13 +95,6 @@ def parse_str_range_option(string: str) -> RangeOption[str]:
     return RangeOption(value, start, end)
 
 
-def parse_str_range_group_option(string: str) -> RangeOptionGroup[str]:
-    if string == '':
-        return RangeOptionGroup([])
-
-    return RangeOptionGroup(list(map(parse_str_range_option, string.split(','))))
-
-
 def parse_int_range_option(string: str) -> RangeOption[int]:
     str_range = parse_str_range_option(string)
 
@@ -109,9 +103,3 @@ def parse_int_range_option(string: str) -> RangeOption[int]:
     except ValueError:
         raise DpsPrepConfigError(f'Expected the value of the range option {string} to be an integer') from None
 
-
-def parse_int_range_group_option(string: str) -> RangeOptionGroup[int]:
-    if string == '':
-        return RangeOptionGroup([])
-
-    return RangeOptionGroup(list(map(parse_int_range_option, string.split(','))))

--- a/src/dpsprep/ranges.py
+++ b/src/dpsprep/ranges.py
@@ -1,0 +1,117 @@
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from dpsprep.exceptions import DpsPrepConfigError
+
+
+T = TypeVar('T')
+
+
+@dataclass(frozen=True)
+class RangeOption(Generic[T]):
+    """A value with a range of one-based pages attached.
+
+    Args:
+        value: The value of the range.
+        start: Either a positive integer or None.
+
+            The special value None indicates that the range is unbounded from below.
+
+        end: Either a positive integer or None.
+
+            The special value None indicates that the range is unbounded from above.
+
+    """
+    value: T
+    start: int | None = None
+    end: int | None = None
+
+    def matches_zero_based_page(self, i: int) -> bool:
+        one_based = i + 1
+
+        if self.start is not None and self.end is not None:
+            return self.start <= one_based <= self.end
+
+        if self.start is not None:
+            return one_based >= self.start
+
+        if self.end is not None:
+            return one_based <= self.end
+
+        return True
+
+
+@dataclass(frozen=True)
+class RangeOptionGroup(Generic[T]):
+    ranges: Sequence[RangeOption[T]]
+
+    def get_value_for_zero_based_page(self, i: int) -> T | None:
+        for range_ in self.ranges:
+            if range_.matches_zero_based_page(i):
+                return range_.value
+
+        return None
+
+    def get_global_value(self) -> T | None:
+        if len(self.ranges) == 1 and self.ranges[0].start == self.ranges[0].end is None:
+            return self.ranges[0].value
+
+        return None
+
+
+def parse_str_range_option(string: str) -> RangeOption[str]:
+    match = re.match(r'(?P<value>[^\[]+)\[(?P<start>\d+)(-(?P<end>(\d+|end)))?\](?P<tail>.+)?', string)
+
+    if match is None:
+        if '[' in string:
+            raise DpsPrepConfigError(f'Invalid range option {string}')
+
+        return RangeOption(string)
+
+    groups = match.groupdict()
+
+    if groups.get('tail'):
+        raise DpsPrepConfigError(f'Unexpected content after slice in range option {string}')
+
+    value: Any
+
+    value = groups['value']
+    start = int(groups['start']) if groups.get('start') else None
+
+    if end_str := groups.get('end'):
+        try:
+            end = int(end_str)
+        except ValueError:
+            end = None
+    else:
+        end = start
+
+    if start is None and end is None:
+        return RangeOption(value)
+
+    return RangeOption(value, start, end)
+
+
+def parse_str_range_group_option(string: str) -> RangeOptionGroup[str]:
+    if string == '':
+        return RangeOptionGroup([])
+
+    return RangeOptionGroup(list(map(parse_str_range_option, string.split(','))))
+
+
+def parse_int_range_option(string: str) -> RangeOption[int]:
+    str_range = parse_str_range_option(string)
+
+    try:
+        return RangeOption[int](int(str_range.value), str_range.start, str_range.end)
+    except ValueError:
+        raise DpsPrepConfigError(f'Expected the value of the range option {string} to be an integer') from None
+
+
+def parse_int_range_group_option(string: str) -> RangeOptionGroup[int]:
+    if string == '':
+        return RangeOptionGroup([])
+
+    return RangeOptionGroup(list(map(parse_int_range_option, string.split(','))))

--- a/src/dpsprep/test_ranges.py
+++ b/src/dpsprep/test_ranges.py
@@ -1,0 +1,30 @@
+import pytest
+
+from dpsprep.exceptions import DpsPrepConfigError
+from dpsprep.ranges import RangeOption, parse_str_range_option
+
+
+class TestParseStrRangeArgument:
+    def test_without_range(self) -> None:
+        assert parse_str_range_option('value') == RangeOption('value')
+
+    def test_empty_range(self) -> None:
+        with pytest.raises(DpsPrepConfigError):
+            assert parse_str_range_option('value[]')
+
+    def test_malformed_range(self) -> None:
+        with pytest.raises(DpsPrepConfigError):
+            assert parse_str_range_option('value[1-]')
+
+    def test_range_with_only_start(self) -> None:
+        assert parse_str_range_option('value[1]') == RangeOption('value', 1, 1)
+
+    def test_unbounded_from_above_range(self) -> None:
+        assert parse_str_range_option('value[1-end]') == RangeOption('value', 1)
+
+    def test_bounded_range(self) -> None:
+        assert parse_str_range_option('value[1-2]') == RangeOption('value', 1, 2)
+
+    def test_tail(self) -> None:
+        with pytest.raises(DpsPrepConfigError):
+            assert parse_str_range_option('value[1-2]tail')

--- a/src/dpsprep/test_ranges.py
+++ b/src/dpsprep/test_ranges.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dpsprep.exceptions import DpsPrepConfigError
-from dpsprep.ranges import RangeOption, parse_str_range_option
+from dpsprep.ranges import RangeOption, RangeOptionGroup, parse_str_range_option
 
 
 class TestParseStrRangeArgument:
@@ -28,3 +28,44 @@ class TestParseStrRangeArgument:
     def test_tail(self) -> None:
         with pytest.raises(DpsPrepConfigError):
             assert parse_str_range_option('value[1-2]tail')
+
+
+class TestRangeOptionGroup:
+    def test_empty_group(self) -> None:
+        group = RangeOptionGroup[str]([])
+        assert group.get_value_for_one_based_page(3) is None
+        assert group.get_global_value() is None
+
+    def test_single_option(self) -> None:
+        group = RangeOptionGroup([parse_str_range_option('a')])
+        assert group.get_value_for_one_based_page(3) == 'a'
+        assert group.get_global_value() == 'a'
+
+    def test_single_option_with_index(self) -> None:
+        group = RangeOptionGroup([parse_str_range_option('a[3]')])
+        assert group.get_value_for_one_based_page(2) is None
+        assert group.get_value_for_one_based_page(3) == 'a'
+        assert group.get_global_value() is None
+
+    def test_single_option_with_bounded_range(self) -> None:
+        group = RangeOptionGroup([parse_str_range_option('a[3-4]')])
+        assert group.get_value_for_one_based_page(2) is None
+        assert group.get_value_for_one_based_page(3) == 'a'
+        assert group.get_value_for_one_based_page(5) is None
+        assert group.get_global_value() is None
+
+    def test_single_option_with_unbounded_range(self) -> None:
+        group = RangeOptionGroup([parse_str_range_option('a[3-end]')])
+        assert group.get_value_for_one_based_page(2) is None
+        assert group.get_value_for_one_based_page(3) == 'a'
+        assert group.get_value_for_one_based_page(5) == 'a'
+        assert group.get_global_value() is None
+
+    def test_two_options(self) -> None:
+        group = RangeOptionGroup([parse_str_range_option('a[1]'), parse_str_range_option('b[3-4]')])
+        assert group.get_value_for_one_based_page(1) == 'a'
+        assert group.get_value_for_one_based_page(2) is None
+        assert group.get_value_for_one_based_page(3) == 'b'
+        assert group.get_value_for_one_based_page(4) == 'b'
+        assert group.get_value_for_one_based_page(5) is None
+        assert group.get_global_value() is None

--- a/src/dpsprep/workflow/processing.py
+++ b/src/dpsprep/workflow/processing.py
@@ -6,7 +6,7 @@ import loguru
 
 from dpsprep.images import failsafe_save_djvu_page, process_djvu_page
 from dpsprep.logging import configure_loguru, human_readable_size
-from dpsprep.options import DpsPrepOptions
+from dpsprep.options import DEFAULT_IMAGE_MODE, DpsPrepOptions
 from dpsprep.outline import extract_text_as_fpdf
 from dpsprep.pdf import is_valid_pdf
 from dpsprep.workdir import WorkingDirectory
@@ -34,18 +34,26 @@ def process_page_bg(workdir: WorkingDirectory, options: DpsPrepOptions, i: int) 
     )
     document.decoding_job.wait()
 
-    page_bg = process_djvu_page(document.pages[i], options.mode, i)
-
+    mode = options.mode_overrides.get_value_for_zero_based_page(i) or DEFAULT_IMAGE_MODE
+    page_bg = process_djvu_page(document.pages[i], mode, i)
     failsafe_save_djvu_page(
         page_bg,
         workdir.get_page_pdf_path(i),
-        options.quality,
-        options.dpi,
+        options,
         page_number,
     )
 
+    dpi_override = options.dpi_overrides.get_value_for_zero_based_page(i)
     pdf_size = workdir.get_page_pdf_path(i).stat().st_size
-    loguru.logger.debug(f'Image data with size {human_readable_size(pdf_size)} from page {page_number} processed in {time() - start_time:.2f}s and written to working directory.')
+
+    message = (
+        f'Processed and saved image data for page {page_number} in {time() - start_time:.2f}s. '
+        f'The result has {page_bg.mode} mode, DPI {page_bg.resolution} '
+        + ('' if dpi_override is None else f'(will be rescaled to {dpi_override}) ') +
+        f'and size {human_readable_size(pdf_size)}.'
+    )
+
+    loguru.logger.debug(message)
 
 
 def process_text(workdir: WorkingDirectory, options: DpsPrepOptions) -> None:
@@ -67,7 +75,7 @@ def process_text(workdir: WorkingDirectory, options: DpsPrepOptions) -> None:
     )
     document.decoding_job.wait()
 
-    fpdf = extract_text_as_fpdf(document, options.dpi)
+    fpdf = extract_text_as_fpdf(document, options)
     fpdf.output(str(workdir.text_layer_pdf_path))
 
     pdf_size = workdir.text_layer_pdf_path.stat().st_size


### PR DESCRIPTION
* Implement page ranges for `--mode`, `--dpi` and `--quality` (see docs).
* Add a `--socr` ("streamlined" OCR) option that abbreviates `--ocr '{"language": ["eng", "grc"]}'` to `--ocrs eng,grc`.
* Add a `-f` short variant for `--overwrite` and deprecate `-o`.
