### PR TITLE
Fix jpg_quality/jpeg_quality field mismatch with OCRmyPDF >=17.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ strict_bytes = false
 module = [
   "click_man.*",
   "djvu.*",
-  "ocrmypdf.*",
+  #"ocrmypdf.*",
   "pdfrw.*",
   "uv_build.*",
 ]

--- a/src/dpsprep/ocrmypdf_adapter.py
+++ b/src/dpsprep/ocrmypdf_adapter.py
@@ -33,6 +33,9 @@ def run_ocrmypdf_optimizer(options: DpsPrepOptions) -> bool:
     quality = options.quality_overrides.get_global_value()
     workdir = options.workdir
 
+    # Detect the OcrOptions JPEG quality key: was renamed in OCRmyPDF 17.10
+    jpg_quality_key = 'jpeg_quality' if 'jpeg_quality' in OcrOptions.model_fields else 'jpg_quality'
+
     omp_options = OcrOptions(
         input_file=workdir.combined_pdf_without_text_path,
         output_file=workdir.combined_pdf_path,
@@ -40,8 +43,8 @@ def run_ocrmypdf_optimizer(options: DpsPrepOptions) -> bool:
         jobs=options.pool_size,
         optimize=options.optlevel,
         # When set to 0, OCRmyPDF's "optimize" function attempts to adjust them
-        jpg_quality=quality or 0,
         png_quality=quality or 0,
+        **{jpg_quality_key: quality or 0},
     )
 
     info = PdfInfo(workdir.combined_pdf_path)

--- a/src/dpsprep/ocrmypdf_adapter.py
+++ b/src/dpsprep/ocrmypdf_adapter.py
@@ -40,9 +40,11 @@ def run_ocrmypdf_optimizer(options: DpsPrepOptions) -> bool:
         jobs=options.pool_size,
         optimize=options.optlevel,
         # When set to 0, OCRmyPDF's "optimize" function attempts to adjust them
-        jpg_quality=quality or 0,
         png_quality=quality or 0,
     )
+
+    # Set jpg_quality via attribute (backwards-compatible setter) rather than constructor kwarg, since the kwarg differs across OMP versions.
+    omp_options.jpg_quality = quality or 0
 
     info = PdfInfo(workdir.combined_pdf_path)
     context = PdfContext(omp_options, workdir.ocrmypdf_tmp_path, workdir.combined_pdf_path, info, None)

--- a/src/dpsprep/ocrmypdf_adapter.py
+++ b/src/dpsprep/ocrmypdf_adapter.py
@@ -33,9 +33,6 @@ def run_ocrmypdf_optimizer(options: DpsPrepOptions) -> bool:
     quality = options.quality_overrides.get_global_value()
     workdir = options.workdir
 
-    # Detect the OcrOptions JPEG quality key: was renamed in OCRmyPDF 17.10
-    jpg_quality_key = 'jpeg_quality' if 'jpeg_quality' in OcrOptions.model_fields else 'jpg_quality'
-
     omp_options = OcrOptions(
         input_file=workdir.combined_pdf_without_text_path,
         output_file=workdir.combined_pdf_path,
@@ -43,8 +40,8 @@ def run_ocrmypdf_optimizer(options: DpsPrepOptions) -> bool:
         jobs=options.pool_size,
         optimize=options.optlevel,
         # When set to 0, OCRmyPDF's "optimize" function attempts to adjust them
+        jpg_quality=quality or 0,
         png_quality=quality or 0,
-        **{jpg_quality_key: quality or 0},
     )
 
     info = PdfInfo(workdir.combined_pdf_path)


### PR DESCRIPTION
Any optimize level (`-O<n>`) crashes on OCRmyPDF >=17.10.0 with:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for OcrOptions
jpg_quality
  Extra inputs are not permitted [type=extra_forbidden, input_value=0, input_type=int]
```

## Reproduction

Any djvu file will do, e.g.:

```bash
wget -q -O sample.djvu "https://upload.wikimedia.org/wikipedia/commons/8/8d/Example_for_DjVu_manual_cz-book_color.djvu"
```

The following crashes with the error above

```bash
uv run --with dpsprep --with 'ocrmypdf>=17.10' dpsprep -O1 sample.djvu sample.pdf
```

## Cause

`src/dpsprep/ocrmypdf_adapter.py` expects the `_options.OcrOptions` field `jpg_quality`, which was renamed to `jpeg_quality` in OCRmyPDF 17.10.0 ([`6f4744dd`](https://github.com/ocrmypdf/OCRmyPDF/commit/6f4744dd20e05231d3602f1e7b2e7e1e2779b2be)). dpsprep constructs `OcrOptions` directly instead of going through `ocrmypdf.ocr()`, which calls `create_options()` to remap deprecated parameter names. So it isn't caught here.

## Fix

In `ocrmypdf_adapter.py`, detect which field name the installed OCRmyPDF's `OcrOptions` has and use that:

```python
jpg_quality_key = 'jpeg_quality' if 'jpeg_quality' in OcrOptions.model_fields else 'jpg_quality'
...
omp_options = OcrOptions(
    ...,
    png_quality=quality or 0,
    **{jpg_quality_key: quality or 0},
)
```

Works across both old 17.8.1 (pre-rename) and new >=17.10 (post-rename) OCRmyPDF versions.

## Notes

- Unrelated and not addressed here: rerunning on the same input after a failed run reuses a stale `/var/tmp/dpsprep/` working dir and hangs. But to rerun dpsprep on the same input after a failure (like when testing for this error) you need to delete the old working dir first.